### PR TITLE
[c_simple] Build on experimental platforms

### DIFF
--- a/c_simple/build_tarballs.jl
+++ b/c_simple/build_tarballs.jl
@@ -1,7 +1,7 @@
 using BinaryBuilder
 
 name = "c_simple"
-version = v"1.2.3"
+version = v"1.2.4"
 
 # Collection of sources required to build libffi
 sources = [
@@ -16,7 +16,7 @@ make install
 
 # These are the platforms we will build for by default, unless further
 # platforms are passed in on the command line
-platforms = supported_platforms()
+platforms = supported_platforms(;experimental=true)
 
 # The products that we will ensure are always built
 products = [
@@ -29,5 +29,5 @@ dependencies = [
 ]
 
 # Build the tarballs, and possibly a `build.jl` as well.
-build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies)
+build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6")
 


### PR DESCRIPTION
Should fix the following Julia test errors on Apple Silicon:
```
LoadError: LoadError: Cannot locate artifact 'c_simple' for aarch64-apple-darwin-libgfortran5-cxx11-julia_version+1.7.0 in '/Users/omus/Development/Julia/arm64/latest/usr/share/julia/stdlib/v1.7/Artifacts/test/Artifacts.toml'
```
```
LoadError: LoadError: Cannot locate artifact 'c_simple' for aarch64-apple-darwin-libgfortran5-cxx11-julia_version+1.7.0 in '/Users/omus/Development/Julia/arm64/latest/usr/share/julia/stdlib/v1.7/LazyArtifacts/test/Artifacts.toml'
```